### PR TITLE
キャッシュ機構を用意

### DIFF
--- a/src/libs/KVWithCache.ts
+++ b/src/libs/KVWithCache.ts
@@ -1,0 +1,43 @@
+export type KVWithCache = {
+  get: (key: string) => Promise<string|null>;
+  deleteCache: (key: string) => Promise<void>;
+  getTTL: () => Promise<void>;
+};
+
+/**
+ * [text] が [badWords] のいずれかにマッチするかどうかを判定する
+ * @param KVNamespace
+ * @returns getの他、getTTLとdeleteCacheのFunctionを持つKVWithCacheオブジェクト
+ */
+export const useKVWithCache = (KV: KVNamespace) : KVWithCache => {
+  let _ttl = 120;
+  const cache = caches.default;
+  const cacheprefix = "https://example.com/";
+  return {
+    async getTTL() {
+      const ttlValue = await this.get("cacheTTL")
+      if (Number.isFinite(Number(ttlValue))) {
+        _ttl = Number(ttlValue)
+      }
+    },
+    async get(key: string, cacheTTL?: number) {
+      const cached = await cache.match(`${cacheprefix}${key}`);
+      if (cached && cached.body) {
+        return cached.text();
+      }
+      let value = await KV.get(key);
+
+      if (value) {
+        const options: ResponseInit = {};
+        if (cacheTTL) {
+          options.headers = { "Cache-Control": `max-age=${cacheTTL}` };
+        }
+        cache.put(key, new Response(value,  options));
+      }
+      return value;
+    },
+    async deleteCache(key: string) {
+      cache.delete(`${cacheprefix}${key}`);
+    },
+  };
+}

--- a/src/libs/KVWithCache.ts
+++ b/src/libs/KVWithCache.ts
@@ -5,13 +5,15 @@ export type KVWithCache = {
 };
 
 /**
- * [text] が [badWords] のいずれかにマッチするかどうかを判定する
+ * KVをキャッシュを用いて取得するKVWithCacheオブジェクトを返す
  * @param KVNamespace
  * @returns getの他、getTTLとdeleteCacheのFunctionを持つKVWithCacheオブジェクト
  */
 export const useKVWithCache = (KV: KVNamespace) : KVWithCache => {
   let _ttl = 120;
   const cache = caches.default;
+
+  // キャッシュにはURL形式にする必要があるため （ただし実在のURLでなくてもよいし、実在するものでも問題ない）
   const cacheprefix = "https://example.com/";
   return {
     async getTTL() {


### PR DESCRIPTION
## What
- KVの値をCacheに載せるようにした

- KVに問い合わせできない時にバイパスを行う（できればオプション化とかしたいかも、いい改善策あればFixしたいです）

## Why
- 毎リクエストKVに問い合わせを行うとKVの無料枠に優しくないため 
  - Reads | 100,000 reads per day
  - FYI: https://developers.cloudflare.com/kv/platform/limits/ 
  -  getを行うたびにreadの値を消化する
- KVに問い合わせできない時に鎖国してしまう